### PR TITLE
タマクラ4のOGP画像のパス修正

### DIFF
--- a/src/pages/events/tmkr04.vue
+++ b/src/pages/events/tmkr04.vue
@@ -818,7 +818,7 @@ export default {
         {
           hid: 'og:image',
           property: 'og:image',
-          content: `${process.env.BASE_URL}/img/logos/tmkr4_logo.png`,
+          content: `${process.env.BASE_URL}/img/logos/tmkr04_logo.png`,
         },
         {
           hid: 'og:description',


### PR DESCRIPTION
タマクラ4のOGP画像のパスが正しくなかったので修正しました。