### PR TITLE
美味しいタマゴ寿司ページのタイトル修正

### DIFF
--- a/src/pages/events/bimitmsushi.vue
+++ b/src/pages/events/bimitmsushi.vue
@@ -396,12 +396,12 @@ export default {
   },
   head() {
     return {
-      title: 'タマクラ4',
+      title: '美味しいタマゴ寿司',
       meta: [
         {
           hid: 'title',
           name: 'title',
-          content: 'タマクラ4 | ヒナクラ'
+          content: '美味しいタマゴ寿司 | ヒナクラ'
         },
         {
           hid: 'description',


### PR DESCRIPTION
美味しいタマゴ寿司ページのタイトルが間違っていたのを修正しました。